### PR TITLE
package.json fix – main: index.json -> index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pouchdb-list",
   "version": "1.1.0",
-  "main": "index.json",
+  "main": "index.js",
   "description": "A PouchDB plug-in that allows you to re-use your CouchDB list functions on the client side.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes the package.json main field.  Package resolvers other than the standard node resolver have a problem with that.